### PR TITLE
removed debug print from output

### DIFF
--- a/bin/AssembleJSeq.py
+++ b/bin/AssembleJSeq.py
@@ -11,6 +11,7 @@ def AssembleJSeq(jseq1_file, jseq2_file):
 
     get_ID = lambda seq: seq[0]
     common_IDs = list(set(map(get_ID, jseq1)) & set(map(get_ID, jseq2)))
+    #print(common_IDs)
 
     jseq1_common = iter(filter(lambda seq: seq[0] in common_IDs, jseq1))
     jseq2_common = iter(filter(lambda seq: seq[0] in common_IDs, jseq2))
@@ -53,7 +54,7 @@ def groupby(group_key, sorted_data):
     else:
         result_box.append(tmp_box)
     return result_box
-    
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This print call in `AssembleJSeq.py` was contaminated one of the intermediate outputs, leading to the ivalid (empty) novoindex:

`print(common_IDs)`

This results in this error condition at the following step `does not appear to be a valid novoindex`